### PR TITLE
fixed device startup

### DIFF
--- a/src/depthai_ros_driver/include/depthai_ros_driver/base_camera.hpp
+++ b/src/depthai_ros_driver/include/depthai_ros_driver/base_camera.hpp
@@ -183,7 +183,7 @@ private:
   BaseCameraConfig base_config_;
   BaseCameraParamNames base_param_names_;
   std::shared_ptr<dai::Pipeline> pipeline_;
-  std::unique_ptr<dai::Device> device_;
+  std::shared_ptr<dai::Device> device_;
   std::shared_ptr<dai::node::ColorCamera> camrgb_;
   std::shared_ptr<dai::node::MonoCamera> mono_left_;
   std::shared_ptr<dai::node::MonoCamera> mono_right_;

--- a/src/depthai_ros_driver/include/depthai_ros_driver/calibration.hpp
+++ b/src/depthai_ros_driver/include/depthai_ros_driver/calibration.hpp
@@ -31,7 +31,7 @@ namespace depthai_ros_driver
 namespace calibration
 {
 sensor_msgs::msg::CameraInfo get_calibration(
-  std::unique_ptr<dai::Device> & device, const std::string & frame_id,
+  std::shared_ptr<dai::Device> device, const std::string & frame_id,
   dai::CameraBoardSocket socket, int width = 0, int height = 0,
   dai::Point2f top_left_pixel_id = {(0.0), (0.0)},
   dai::Point2f bottom_right_pixel_id = {(0.0), (0.0)});

--- a/src/depthai_ros_driver/src/base_camera.cpp
+++ b/src/depthai_ros_driver/src/base_camera.cpp
@@ -580,7 +580,7 @@ void BaseCamera::enc_cb(
     }
     auto enc_in = std::dynamic_pointer_cast<dai::ImgFrame>(data);
     video_file_.write(
-      (char *)(enc_in->getData().data()),
+      reinterpret_cast<char *>(enc_in->getData().data()),
       enc_in->getData().size());
   }
 }
@@ -719,4 +719,4 @@ void BaseCamera::declare_common_params()
     this->declare_parameter<std::string>(base_param_names_.camera_ip, "");
 }
 
-} // namespace depthai_ros_driver
+}  // namespace depthai_ros_driver

--- a/src/depthai_ros_driver/src/base_camera.cpp
+++ b/src/depthai_ros_driver/src/base_camera.cpp
@@ -54,32 +54,42 @@
 namespace depthai_ros_driver
 {
 BaseCamera::BaseCamera(
-  const std::string & name, const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
+  const std::string & name,
+  const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
 : rclcpp::Node(name, options)
 {
+  RCLCPP_INFO(this->get_logger(), "Initialzing camera...");
   cam_running_ = false;
-  pipeline_ = std::make_unique<dai::Pipeline>();
+  pipeline_ = std::make_shared<dai::Pipeline>();
   start_cam_srv_ = this->create_service<Trigger>(
     "~/start_camera",
-    std::bind(&BaseCamera::start_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::start_cb, this, std::placeholders::_1,
+      std::placeholders::_2));
   shutdown_cam_srv_ = this->create_service<Trigger>(
     "~/shutdown_camera",
-    std::bind(&BaseCamera::shutdown_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::shutdown_cb, this, std::placeholders::_1,
+      std::placeholders::_2));
 
   restart_cam_srv_ = this->create_service<Trigger>(
     "~/restart_camera",
-    std::bind(&BaseCamera::restart_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::restart_cb, this, std::placeholders::_1,
+      std::placeholders::_2));
 }
 
 void BaseCamera::restart_cb(
-  const Trigger::Request::SharedPtr /*req*/, Trigger::Response::SharedPtr res)
+  const Trigger::Request::SharedPtr /*req*/,
+  Trigger::Response::SharedPtr res)
 {
   restart_device();
   res->success = true;
 }
 
 void BaseCamera::start_cb(
-  const Trigger::Request::SharedPtr /*req*/, Trigger::Response::SharedPtr res)
+  const Trigger::Request::SharedPtr /*req*/,
+  Trigger::Response::SharedPtr res)
 {
   if (cam_running_) {
     RCLCPP_INFO(this->get_logger(), "Camera already running.");
@@ -103,7 +113,8 @@ void BaseCamera::set_frame_ids()
   };
 }
 void BaseCamera::shutdown_cb(
-  const Trigger::Request::SharedPtr /*req*/, Trigger::Response::SharedPtr res)
+  const Trigger::Request::SharedPtr /*req*/,
+  Trigger::Response::SharedPtr res)
 {
   RCLCPP_INFO(this->get_logger(), "Shutting down camera");
   if (!cam_running_) {
@@ -125,7 +136,10 @@ void BaseCamera::restart_device()
   setup_all_queues();
 }
 
-void BaseCamera::create_pipeline() {pipeline_ = std::make_unique<dai::Pipeline>();}
+void BaseCamera::create_pipeline()
+{
+  pipeline_ = std::make_shared<dai::Pipeline>();
+}
 
 void BaseCamera::start_device()
 {
@@ -133,11 +147,7 @@ void BaseCamera::start_device()
   dai::DeviceInfo info;
   bool device_found;
   if (!base_config_.camera_mxid.empty()) {
-    std::tie(device_found, info) = dai::Device::getDeviceByMxId(base_config_.camera_mxid);
-    if (!device_found) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Device with id: %s not found!", base_config_.camera_mxid.c_str());
-    }
+    info = dai::DeviceInfo(base_config_.camera_mxid);
   } else if (!base_config_.camera_ip.empty()) {
     info = dai::DeviceInfo(base_config_.camera_ip);
   }
@@ -145,9 +155,9 @@ void BaseCamera::start_device()
   while (!cam_setup) {
     try {
       if (base_config_.camera_mxid.empty() && base_config_.camera_ip.empty()) {
-        device_ = std::make_unique<dai::Device>(*pipeline_, dai::UsbSpeed::SUPER_PLUS);
+        device_ = std::make_shared<dai::Device>(*pipeline_, dai::UsbSpeed::SUPER_PLUS);
       } else {
-        device_ = std::make_unique<dai::Device>(*pipeline_, info, dai::UsbSpeed::SUPER_PLUS);
+        device_ = std::make_shared<dai::Device>(*pipeline_, info, dai::UsbSpeed::SUPER_PLUS);
       }
       cam_setup = true;
     } catch (const std::runtime_error & e) {
@@ -211,25 +221,30 @@ void BaseCamera::setup_imu()
 
 void BaseCamera::setup_stereo()
 {
-  RCLCPP_INFO(this->get_logger(), "Creating DEPTH.");
+  RCLCPP_INFO(this->get_logger(), "Creating depth.");
   mono_left_ = pipeline_->create<dai::node::MonoCamera>();
   mono_right_ = pipeline_->create<dai::node::MonoCamera>();
   stereo_ = pipeline_->create<dai::node::StereoDepth>();
 
   mono_left_->setBoardSocket(dai::CameraBoardSocket::LEFT);
   mono_right_->setBoardSocket(dai::CameraBoardSocket::RIGHT);
-  stereo_params_handler_->setup_stereo(stereo_, mono_left_, mono_right_, this->get_logger());
+  stereo_params_handler_->setup_stereo(
+    stereo_, mono_left_, mono_right_,
+    this->get_logger());
   mono_left_->out.link(stereo_->left);
   mono_right_->out.link(stereo_->right);
   RCLCPP_INFO(this->get_logger(), "Created.");
 }
 void BaseCamera::setup_logger()
 {
+  RCLCPP_INFO(this->get_logger(), "Creating logger.");
   logger_ = pipeline_->create<dai::node::SystemLogger>();
   logger_->setRate(1.0);
+  RCLCPP_INFO(this->get_logger(), "Created.");
 }
 void BaseCamera::trig_rec_cb(
-  const Trigger::Request::SharedPtr /*req*/, Trigger::Response::SharedPtr /*res*/)
+  const Trigger::Request::SharedPtr /*req*/,
+  Trigger::Response::SharedPtr /*res*/)
 {
   if (!record_) {
     RCLCPP_INFO(this->get_logger(), "Starting recording.");
@@ -247,13 +262,16 @@ void BaseCamera::setup_recording()
     dai::VideoEncoderProperties::Profile::H264_MAIN);
   trigger_recording_srv_ = this->create_service<Trigger>(
     "~/trigger_recording",
-    std::bind(&BaseCamera::trig_rec_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::trig_rec_cb, this, std::placeholders::_1,
+      std::placeholders::_2));
 }
 void BaseCamera::declare_rgb_depth_params()
 {
   declare_common_params();
   rgb_params_handler_ = std::make_unique<rgb_params::RGBParamsHandler>();
-  stereo_params_handler_ = std::make_unique<stereo_params::StereoParamsHandler>();
+  stereo_params_handler_ =
+    std::make_unique<stereo_params::StereoParamsHandler>();
   rgb_params_handler_->declare_rgb_params(this);
   stereo_params_handler_->declare_depth_params(this);
   set_frame_ids();
@@ -322,8 +340,11 @@ void BaseCamera::setup_all_xout_streams()
     setup_imu_xout();
   }
 }
-sensor_msgs::msg::Image BaseCamera::convert_img_to_ros(
-  const cv::Mat & frame, const char * encoding, const std::string & frame_id, rclcpp::Time stamp)
+sensor_msgs::msg::Image
+BaseCamera::convert_img_to_ros(
+  const cv::Mat & frame, const char * encoding,
+  const std::string & frame_id,
+  rclcpp::Time stamp)
 {
   cv_bridge::CvImage img_bridge;
   sensor_msgs::msg::Image img_msg;
@@ -335,21 +356,30 @@ sensor_msgs::msg::Image BaseCamera::convert_img_to_ros(
   return img_msg;
 }
 void BaseCamera::publish_img(
-  const cv::Mat & img, const char * encoding, sensor_msgs::msg::CameraInfo & info,
-  const image_transport::CameraPublisher & pub, rclcpp::Time stamp)
+  const cv::Mat & img, const char * encoding,
+  sensor_msgs::msg::CameraInfo & info,
+  const image_transport::CameraPublisher & pub,
+  rclcpp::Time stamp)
 {
   info.header.stamp = stamp;
-  pub.publish(convert_img_to_ros(img, encoding, info.header.frame_id, info.header.stamp), info);
+  pub.publish(
+    convert_img_to_ros(
+      img, encoding, info.header.frame_id,
+      info.header.stamp),
+    info);
 }
 
 void BaseCamera::regular_queue_cb(
-  const std::string & name, const std::shared_ptr<dai::ADatatype> & data)
+  const std::string & name,
+  const std::shared_ptr<dai::ADatatype> & data)
 {
   auto frame = std::dynamic_pointer_cast<dai::ImgFrame>(data);
   cv::Mat cv_frame = frame->getCvFrame();
   auto curr_time = this->get_clock()->now();
   if (name == rgb_q_name_) {
-    publish_img(cv_frame, sensor_msgs::image_encodings::BGR8, rgb_info_, rgb_pub_, curr_time);
+    publish_img(
+      cv_frame, sensor_msgs::image_encodings::BGR8, rgb_info_,
+      rgb_pub_, curr_time);
   } else if (name == depth_q_name_) {
     if (stereo_params_handler_->get_init_config().align_depth) {
       cv::resize(
@@ -359,14 +389,21 @@ void BaseCamera::regular_queue_cb(
           rgb_params_handler_->get_init_config().rgb_height));
     }
     publish_img(
-      cv_frame, sensor_msgs::image_encodings::TYPE_16UC1, depth_info_, depth_pub_, curr_time);
+      cv_frame, sensor_msgs::image_encodings::TYPE_16UC1, depth_info_,
+      depth_pub_, curr_time);
   } else if (name == left_q_name_) {
-    publish_img(cv_frame, sensor_msgs::image_encodings::MONO8, left_info_, left_pub_, curr_time);
+    publish_img(
+      cv_frame, sensor_msgs::image_encodings::MONO8, left_info_,
+      left_pub_, curr_time);
   } else if (name == right_q_name_) {
-    publish_img(cv_frame, sensor_msgs::image_encodings::MONO8, right_info_, right_pub_, curr_time);
+    publish_img(
+      cv_frame, sensor_msgs::image_encodings::MONO8, right_info_,
+      right_pub_, curr_time);
   }
 }
-void BaseCamera::imu_cb(const std::string & name, const std::shared_ptr<dai::ADatatype> & data)
+void BaseCamera::imu_cb(
+  const std::string & name,
+  const std::shared_ptr<dai::ADatatype> & data)
 {
   auto imu_data = std::dynamic_pointer_cast<dai::IMUData>(data);
   auto packets = imu_data->packets;
@@ -393,33 +430,42 @@ void BaseCamera::imu_cb(const std::string & name, const std::shared_ptr<dai::ADa
     // https://github.com/Vijfendertig/rosserial_adafruit_bno055/blob/532b63db9b0e5e5e9217bd89905001fe979df3a4/src/imu_publisher/imu_publisher.cpp#L42.
     for (unsigned row = 0; row < 3; ++row) {
       for (unsigned col = 0; col < 3; ++col) {
-        imu_msg.orientation_covariance[row * 3 + col] = (row == col ? 0.002 : 0.);       // +-2.5deg
-        imu_msg.angular_velocity_covariance[row * 3 + col] = (row == col ? 0.003 : 0.);  // +-3deg/s
-        imu_msg.linear_acceleration_covariance[row * 3 + col] = (row == col ? 0.60 : 0.);  // +-80mg
+        imu_msg.orientation_covariance[row * 3 + col] =
+          (row == col ? 0.002 : 0.);   // +-2.5deg
+        imu_msg.angular_velocity_covariance[row * 3 + col] =
+          (row == col ? 0.003 : 0.);   // +-3deg/s
+        imu_msg.linear_acceleration_covariance[row * 3 + col] =
+          (row == col ? 0.60 : 0.);   // +-80mg
       }
     }
     imu_pub_->publish(imu_msg);
   }
 }
-void BaseCamera::logger_cb(const std::string & name, const std::shared_ptr<dai::ADatatype> & data)
+void BaseCamera::logger_cb(
+  const std::string & name,
+  const std::shared_ptr<dai::ADatatype> & data)
 {
   auto info = std::dynamic_pointer_cast<dai::SystemInformation>(data);
   std::stringstream msg;
-  msg << "Ddr used / total - " << info->ddrMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
+  msg << "Ddr used / total - " <<
+    info->ddrMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
     info->ddrMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
     "\n";
-  msg << "Cmx used / total - " << info->cmxMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
+  msg << "Cmx used / total - " <<
+    info->cmxMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
     info->cmxMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
     "\n";
-  msg << "LeonCss heap used / total - " << info->leonCssMemoryUsage.used / (1024.0f * 1024.0f) <<
-    "/" << info->leonCssMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
+  msg << "LeonCss heap used / total - " <<
+    info->leonCssMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
+    info->leonCssMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
     "\n";
-  msg << "LeonMss heap used / total - " << info->leonMssMemoryUsage.used / (1024.0f * 1024.0f) <<
-    "/" << info->leonMssMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
+  msg << "LeonMss heap used / total - " <<
+    info->leonMssMemoryUsage.used / (1024.0f * 1024.0f) << "/" <<
+    info->leonMssMemoryUsage.total / (1024.0f * 1024.0f) << "MiB" <<
     "\n";
   const auto & t = info->chipTemperature;
-  msg << "Chip temperature - average: " << t.average << " css: " << t.css << " mss: " << t.mss <<
-    " upa: " << t.upa << " dss: " << t.dss << "\n";
+  msg << "Chip temperature - average: " << t.average << " css: " << t.css <<
+    " mss: " << t.mss << " upa: " << t.upa << " dss: " << t.dss << "\n";
   msg << "Cpu usage - Leon CSS: " << info->leonCssCpuUsage.average * 100 <<
     "%% Leon MSS: " << info->leonMssCpuUsage.average * 100 << "%%" <<
     "\n";
@@ -432,90 +478,129 @@ void BaseCamera::logger_cb(const std::string & name, const std::shared_ptr<dai::
   diag.status[0].message = msg.str();
   diag_pub_->publish(diag);
 }
-sensor_msgs::msg::CameraInfo BaseCamera::get_calibration(
-  const std::string & frame_id, dai::CameraBoardSocket socket, int width, int height,
-  dai::Point2f top_left_pixel_id, dai::Point2f bottom_right_pixel_id)
+sensor_msgs::msg::CameraInfo
+BaseCamera::get_calibration(
+  const std::string & frame_id,
+  dai::CameraBoardSocket socket, int width,
+  int height, dai::Point2f top_left_pixel_id,
+  dai::Point2f bottom_right_pixel_id)
 {
   return calibration::get_calibration(
-    device_, frame_id, socket, width, height, top_left_pixel_id, bottom_right_pixel_id);
+    device_, frame_id, socket, width, height,
+    top_left_pixel_id, bottom_right_pixel_id);
 }
 void BaseCamera::enable_rgb_q()
 {
-  rgb_pub_ = image_transport::create_camera_publisher(this, "~/color/image_raw");
+  rgb_pub_ =
+    image_transport::create_camera_publisher(this, "~/color/image_raw");
   rgb_info_ = get_calibration(
     frame_ids_.at(dai::CameraBoardSocket::RGB), dai::CameraBoardSocket::RGB,
     rgb_params_handler_->get_init_config().rgb_width,
     rgb_params_handler_->get_init_config().rgb_height);
   rgb_q_ = device_->getOutputQueue(rgb_q_name_, base_config_.max_q_size, false);
   rgb_q_->addCallback(
-    std::bind(&BaseCamera::regular_queue_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::regular_queue_cb, this,
+      std::placeholders::_1, std::placeholders::_2));
 }
 void BaseCamera::enable_depth_q()
 {
-  depth_pub_ = image_transport::create_camera_publisher(this, "~/depth/image_raw");
+  depth_pub_ =
+    image_transport::create_camera_publisher(this, "~/depth/image_raw");
   if (stereo_params_handler_->get_init_config().align_depth) {
     depth_info_ = get_calibration(
       frame_ids_.at(dai::CameraBoardSocket::RGB), dai::CameraBoardSocket::RGB,
       rgb_params_handler_->get_init_config().rgb_width,
       rgb_params_handler_->get_init_config().rgb_height);
   } else {
-    depth_info_ =
-      get_calibration(frame_ids_.at(dai::CameraBoardSocket::RIGHT), dai::CameraBoardSocket::RIGHT);
+    depth_info_ = get_calibration(
+      frame_ids_.at(dai::CameraBoardSocket::RIGHT),
+      dai::CameraBoardSocket::RIGHT);
   }
-  depth_q_ = device_->getOutputQueue(depth_q_name_, base_config_.max_q_size, false);
+  depth_q_ =
+    device_->getOutputQueue(depth_q_name_, base_config_.max_q_size, false);
   depth_q_->addCallback(
-    std::bind(&BaseCamera::regular_queue_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::regular_queue_cb, this,
+      std::placeholders::_1,
+      std::placeholders::_2));
 }
 void BaseCamera::setup_lr_q()
 {
-  left_pub_ = image_transport::create_camera_publisher(this, "~/left/image_raw");
-  left_info_ =
-    get_calibration(frame_ids_.at(dai::CameraBoardSocket::LEFT), dai::CameraBoardSocket::LEFT);
-  right_pub_ = image_transport::create_camera_publisher(this, "~/right/image_raw");
-  right_info_ =
-    get_calibration(frame_ids_.at(dai::CameraBoardSocket::RIGHT), dai::CameraBoardSocket::RIGHT);
+  left_pub_ =
+    image_transport::create_camera_publisher(this, "~/left/image_raw");
+  left_info_ = get_calibration(
+    frame_ids_.at(dai::CameraBoardSocket::LEFT),
+    dai::CameraBoardSocket::LEFT);
+  right_pub_ =
+    image_transport::create_camera_publisher(this, "~/right/image_raw");
+  right_info_ = get_calibration(
+    frame_ids_.at(dai::CameraBoardSocket::RIGHT),
+    dai::CameraBoardSocket::RIGHT);
 
-  left_q_ = device_->getOutputQueue(left_q_name_, base_config_.max_q_size, false);
+  left_q_ =
+    device_->getOutputQueue(left_q_name_, base_config_.max_q_size, false);
   left_q_->addCallback(
-    std::bind(&BaseCamera::regular_queue_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::regular_queue_cb, this,
+      std::placeholders::_1, std::placeholders::_2));
 
-  right_q_ = device_->getOutputQueue(right_q_name_, base_config_.max_q_size, false);
+  right_q_ =
+    device_->getOutputQueue(right_q_name_, base_config_.max_q_size, false);
   right_q_->addCallback(
-    std::bind(&BaseCamera::regular_queue_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::regular_queue_cb, this,
+      std::placeholders::_1,
+      std::placeholders::_2));
 }
 void BaseCamera::setup_imu_q()
 {
   imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>("~/imu/data", 10);
   imu_q_ = device_->getOutputQueue(imu_q_name_, base_config_.max_q_size, false);
   imu_q_->addCallback(
-    std::bind(&BaseCamera::imu_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::imu_cb, this,
+      std::placeholders::_1, std::placeholders::_2));
 }
-void BaseCamera::enc_cb(const std::string & name, const std::shared_ptr<dai::ADatatype> & data)
+void BaseCamera::enc_cb(
+  const std::string & name,
+  const std::shared_ptr<dai::ADatatype> & data)
 {
   if (record_) {
     if (!started_recording_) {
       std::stringstream current_time;
       auto now = std::chrono::system_clock::now();
       auto in_time_t = std::chrono::system_clock::to_time_t(now);
-      current_time << std::put_time(std::localtime(&in_time_t), "%Y_%m_%d_%H_%M_%S");
+      current_time << std::put_time(
+        std::localtime(&in_time_t),
+        "%Y_%m_%d_%H_%M_%S");
       current_time << ".h265";
       video_file_ = std::ofstream(current_time.str(), std::ios::binary);
       started_recording_ = true;
     }
     auto enc_in = std::dynamic_pointer_cast<dai::ImgFrame>(data);
-    video_file_.write(reinterpret_cast<char *>(enc_in->getData().data()), enc_in->getData().size());
+    video_file_.write(
+      (char *)(enc_in->getData().data()),
+      enc_in->getData().size());
   }
 }
 
 void BaseCamera::setup_recording_q()
 {
-  enc_q_ = device_->getOutputQueue(video_enc_q_name_, base_config_.max_q_size, false);
+  enc_q_ = device_->getOutputQueue(
+    video_enc_q_name_, base_config_.max_q_size,
+    false);
   enc_q_->addCallback(
-    std::bind(&BaseCamera::enc_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::enc_cb, this,
+      std::placeholders::_1, std::placeholders::_2));
 }
-void BaseCamera::setup_control_q() {control_q_ = device_->getInputQueue(control_q_name_);}
-rcl_interfaces::msg::SetParametersResult BaseCamera::parameter_cb(
-  const std::vector<rclcpp::Parameter> & params)
+void BaseCamera::setup_control_q()
+{
+  control_q_ = device_->getInputQueue(control_q_name_);
+}
+rcl_interfaces::msg::SetParametersResult
+BaseCamera::parameter_cb(const std::vector<rclcpp::Parameter> & params)
 {
   rgb_params_handler_->set_runtime_config(params);
   auto ctrl = rgb_params_handler_->get_rgb_control();
@@ -524,14 +609,21 @@ rcl_interfaces::msg::SetParametersResult BaseCamera::parameter_cb(
   res.successful = true;
   return res;
 }
-void BaseCamera::setup_config_q() {config_q_ = device_->getInputQueue(config_q_name_);}
+void BaseCamera::setup_config_q()
+{
+  config_q_ = device_->getInputQueue(config_q_name_);
+}
 void BaseCamera::setup_logger_q()
 {
   diag_pub_ = this->create_publisher<DiagnosticArray>("~/diagnostics", 10);
 
-  logger_q_ = device_->getOutputQueue(logger_q_name_, base_config_.max_q_size, false);
+  logger_q_ =
+    device_->getOutputQueue(logger_q_name_, base_config_.max_q_size, false);
   logger_q_->addCallback(
-    std::bind(&BaseCamera::logger_cb, this, std::placeholders::_1, std::placeholders::_2));
+    std::bind(
+      &BaseCamera::logger_cb, this,
+      std::placeholders::_1,
+      std::placeholders::_2));
 }
 void BaseCamera::setup_all_queues()
 {
@@ -559,8 +651,10 @@ void BaseCamera::setup_all_queues()
     std::bind(&BaseCamera::parameter_cb, this, std::placeholders::_1));
 }
 std::shared_ptr<dai::Pipeline> BaseCamera::get_pipeline() {return pipeline_;}
-std::shared_ptr<dai::DataOutputQueue> BaseCamera::get_output_q(
-  const std::string & q_name, uint8_t max_q_size, bool blocking)
+std::shared_ptr<dai::DataOutputQueue>
+BaseCamera::get_output_q(
+  const std::string & q_name, uint8_t max_q_size,
+  bool blocking)
 {
   return device_->getOutputQueue(q_name, max_q_size, blocking);
 }
@@ -568,47 +662,61 @@ std::string BaseCamera::get_frame_id(const dai::CameraBoardSocket & socket)
 {
   return frame_ids_.at(socket);
 }
-std::vector<std::string> BaseCamera::get_default_label_map() {return default_label_map_;}
+std::vector<std::string> BaseCamera::get_default_label_map()
+{
+  return default_label_map_;
+}
 
 void BaseCamera::link_nn(std::shared_ptr<dai::node::NeuralNetwork> nn)
 {
   camrgb_->preview.link(nn->input);
 }
-void BaseCamera::link_spatial_detection(std::shared_ptr<dai::node::SpatialDetectionNetwork> nn)
+void BaseCamera::link_spatial_detection(
+  std::shared_ptr<dai::node::SpatialDetectionNetwork> nn)
 {
   camrgb_->preview.link(nn->input);
   stereo_->depth.link(nn->inputDepth);
 }
-void BaseCamera::override_init_rgb_config(const rgb_params::RGBInitConfig & config)
+void BaseCamera::override_init_rgb_config(
+  const rgb_params::RGBInitConfig & config)
 {
   rgb_params_handler_->set_init_config(config);
 }
-void BaseCamera::override_runtime_rgb_config(const rgb_params::RGBRuntimeConfig & config)
+void BaseCamera::override_runtime_rgb_config(
+  const rgb_params::RGBRuntimeConfig & config)
 {
   rgb_params_handler_->set_runtime_config(config);
 }
-void BaseCamera::override_init_stereo_config(const stereo_params::StereoInitConfig & config)
+void BaseCamera::override_init_stereo_config(
+  const stereo_params::StereoInitConfig & config)
 {
   stereo_params_handler_->set_init_config(config);
 }
-void BaseCamera::override_runtime_stereo_config(const stereo_params::StereoRuntimeConfig & config)
+void BaseCamera::override_runtime_stereo_config(
+  const stereo_params::StereoRuntimeConfig & config)
 {
   stereo_params_handler_->set_runtime_config(config);
 }
 void BaseCamera::declare_common_params()
 {
-  base_config_.enable_rgb = this->declare_parameter<bool>(base_param_names_.enable_rgb, true);
-  base_config_.enable_depth = this->declare_parameter<bool>(base_param_names_.enable_depth, true);
-  base_config_.enable_lr = this->declare_parameter<bool>(base_param_names_.enable_lr, true);
-  base_config_.enable_imu = this->declare_parameter<bool>(base_param_names_.enable_imu, true);
+  base_config_.enable_rgb =
+    this->declare_parameter<bool>(base_param_names_.enable_rgb, true);
+  base_config_.enable_depth =
+    this->declare_parameter<bool>(base_param_names_.enable_depth, true);
+  base_config_.enable_lr =
+    this->declare_parameter<bool>(base_param_names_.enable_lr, true);
+  base_config_.enable_imu =
+    this->declare_parameter<bool>(base_param_names_.enable_imu, false);
   base_config_.enable_recording =
     this->declare_parameter<bool>(base_param_names_.enable_recording, false);
   base_config_.enable_logging =
     this->declare_parameter<bool>(base_param_names_.enable_logging, false);
-  base_config_.max_q_size = this->declare_parameter<int>(base_param_names_.max_q_size, 4);
+  base_config_.max_q_size =
+    this->declare_parameter<int>(base_param_names_.max_q_size, 4);
   base_config_.camera_mxid =
     this->declare_parameter<std::string>(base_param_names_.camera_mxid, "");
-  base_config_.camera_ip = this->declare_parameter<std::string>(base_param_names_.camera_ip, "");
+  base_config_.camera_ip =
+    this->declare_parameter<std::string>(base_param_names_.camera_ip, "");
 }
 
-}  // namespace depthai_ros_driver
+} // namespace depthai_ros_driver

--- a/src/depthai_ros_driver/src/calibration.cpp
+++ b/src/depthai_ros_driver/src/calibration.cpp
@@ -32,7 +32,7 @@ namespace depthai_ros_driver
 namespace calibration
 {
 sensor_msgs::msg::CameraInfo get_calibration(
-  std::unique_ptr<dai::Device> & device, const std::string & frame_id,
+  std::shared_ptr<dai::Device> device, const std::string & frame_id,
   dai::CameraBoardSocket socket, int width, int height, dai::Point2f top_left_pixel_id,
   dai::Point2f bottom_right_pixel_id)
 {


### PR DESCRIPTION
* fixed issue when calling `getDeviceByMxId` would cause `double free detected in tcache 2` (cause unknown)
* reverdet `depthai-core` version to [ce8b527](https://github.com/luxonis/depthai-core/tree/ce8b527be57485a5d252a87f8284f55d2a914e9e), since it caused additional errors with rpc (cause unknown yet, to be investigated)
* changed device_ object from `unique` to `shared` ptr
* some reformatting